### PR TITLE
Error with callbacks and sub paths

### DIFF
--- a/lib/wrest/callback.rb
+++ b/lib/wrest/callback.rb
@@ -17,6 +17,8 @@ module Wrest
       elsif callable.is_a?(Proc)
         @callback_hash = {}
         callable.call(self)
+      elsif callable.is_a?(Callback)
+        @callback_hash = callable.callback_hash.dup
       end
     end
 
@@ -24,7 +26,7 @@ module Wrest
       merged_callback_hash = callback_hash.clone
       other_callback_hash = callback.callback_hash
       other_callback_hash.each do |code, callback_blocks|
-        merged_callback_hash[code] ||= [] 
+        merged_callback_hash[code] ||= []
         merged_callback_hash[code] += callback_blocks
       end
       Callback.new(merged_callback_hash)

--- a/spec/wrest/callback_spec.rb
+++ b/spec/wrest/callback_spec.rb
@@ -17,6 +17,12 @@ module Wrest
         end
       end
 
+      it "should create a new Callback instance with copy of callback_hash given a Callback instance" do
+          hash = {200 => [lambda{|response| }]}
+          callback = Callback.new hash
+          Callback.new(callback).callback_hash.should == hash
+      end
+
       it "should create a new Callback instance with callback_hash as a key/value pair of HTTP code and collection of lambdas given a block" do
         block = lambda do |callback|
           callback.on_ok{|response| }
@@ -36,7 +42,7 @@ module Wrest
         on_another_ok = false
 
         hash = {200 => lambda{|response| on_ok = true}}
-        block = lambda do |callback| 
+        block = lambda do |callback|
           callback.on_ok{|response| on_another_ok = true}
         end
         uri_callback = Callback.new(hash)

--- a/spec/wrest/uri_spec.rb
+++ b/spec/wrest/uri_spec.rb
@@ -22,20 +22,20 @@ module Wrest
     it "should handle URIs" do
       Uri.new('https://localhost:3000').should == Uri.new(URI.parse('https://localhost:3000'))
     end
-    
+
     it "should know when it is https" do
       Uri.new('https://localhost:3000').should be_https
     end
-    
+
     context 'UriTemplate' do
-      it "should be able to create a UriTemplate given a uri" do    
+      it "should be able to create a UriTemplate given a uri" do
         "http://localhost:3000".to_uri.to_template('/user/:name').should == UriTemplate.new("http://localhost:3000/user/:name")
       end
-      
+
       it "should pass options to the uriTemplate being built" do
         "http://localhost:3000".to_uri(:name => 'abc').to_template('/user/:name').to_uri.should == "http://localhost:3000/user/abc".to_uri
       end
-      
+
       it "should handle / positions with wisdom while creating UriTemplate from a given Uri" do
         "http://localhost:3000/".to_uri.to_template('/user/:name').should == UriTemplate.new("http://localhost:3000/user/:name")
         "http://localhost:3000".to_uri.to_template('/user/:name').should == UriTemplate.new("http://localhost:3000/user/:name")
@@ -47,7 +47,7 @@ module Wrest
     it "should know when it is not https" do
       Uri.new('http://localhost:3000').should_not be_https
     end
-    
+
     context 'extension' do
       it "should know how to build a new uri from an existing one by appending a path" do
         Uri.new('http://localhost:3000')['/ooga/booga'].should == Uri.new('http://localhost:3000/ooga/booga')
@@ -56,7 +56,7 @@ module Wrest
       it "should not lose bits of the path along the way" do
         Uri.new('http://localhost:3000/ooga')['/booga'].should == Uri.new('http://localhost:3000/ooga/booga')
       end
-      
+
       it "should handle / positions with wisdom" do
         Uri.new('http://localhost:3000/')['/ooga/booga'].should == Uri.new('http://localhost:3000/ooga/booga')
         Uri.new('http://localhost:3000')['/ooga/booga'].should == Uri.new('http://localhost:3000/ooga/booga')
@@ -64,12 +64,12 @@ module Wrest
         Uri.new('http://localhost:3000')['ooga/booga'].should == Uri.new('http://localhost:3000/ooga/booga')
       end
     end
-    
+
     it "should know its full path" do
       Uri.new('http://localhost:3000/ooga').full_path.should == '/ooga'
       Uri.new('http://localhost:3000/ooga?foo=meh&bar=1').full_path.should == '/ooga?foo=meh&bar=1'
     end
-        
+
     it "should know its host" do
       Uri.new('http://localhost:3000/ooga').host.should == 'localhost'
     end
@@ -81,11 +81,11 @@ module Wrest
 
     it "should include the username and password while building a new uri if no options are provided" do
       Uri.new(
-        'http://localhost:3000', 
-        :username => 'foo', 
+        'http://localhost:3000',
+        :username => 'foo',
         :password => 'bar')['/ooga/booga'].should == Uri.new(
-                                                      'http://localhost:3000/ooga/booga', 
-                                                      :username => 'foo', 
+                                                      'http://localhost:3000/ooga/booga',
+                                                      :username => 'foo',
                                                       :password => 'bar')
     end
 
@@ -94,7 +94,7 @@ module Wrest
       uri = Uri.new('http://localhost:3000', :username => 'foo', :password => 'bar')
       uri.username.should == 'foo'
       uri.password.should == 'bar'
-      
+
       extended_uri = uri['/ooga/booga', {:username => 'meh', :password => 'baz'}]
       extended_uri.username.should == 'meh'
       extended_uri.password.should == 'baz'
@@ -106,17 +106,17 @@ module Wrest
       Uri.new('http://localhost:3000', :username => 'foo', :password => 'bar').to_s.should == 'http://localhost:3000'
       Uri.new('http://foo:bar@localhost:3000').to_s.should == 'http://foo:bar@localhost:3000'
     end
-    
+
     describe 'Equals' do
       it "should understand equality" do
         Uri.new('https://localhost:3000/ooga').should_not == nil
         Uri.new('https://localhost:3000/ooga').should_not == 'https://localhost:3000/ooga'
         Uri.new('https://localhost:3000/ooga').should_not == Uri.new('https://localhost:3000/booga')
-        
+
         Uri.new('https://ooga:booga@localhost:3000/ooga').should_not == Uri.new('https://foo:bar@localhost:3000/booga')
         Uri.new('http://ooga:booga@localhost:3000/ooga').should_not == Uri.new('http://foo:bar@localhost:3000/booga')
         Uri.new('http://localhost:3000/ooga').should_not == Uri.new('http://foo:bar@localhost:3000/booga')
-        
+
         Uri.new('http://localhost:3000?owner=kai&type=bottle').should_not == Uri.new('http://localhost:3000/')
         Uri.new('http://localhost:3000?owner=kai&type=bottle').should_not == Uri.new('http://localhost:3000?')
         Uri.new('http://localhost:3000?owner=kai&type=bottle').should_not == Uri.new('http://localhost:3000?type=bottle&owner=kai')
@@ -124,7 +124,7 @@ module Wrest
         Uri.new('https://localhost:3000').should_not == Uri.new('https://localhost:3500')
         Uri.new('https://localhost:3000').should_not == Uri.new('http://localhost:3000')
         Uri.new('http://localhost:3000', :username => 'ooga', :password => 'booga').should_not == Uri.new('http://ooga:booga@localhost:3000')
-                
+
         Uri.new('http://localhost:3000').should == Uri.new('http://localhost:3000')
         Uri.new('http://localhost:3000', :username => 'ooga', :password => 'booga').should == Uri.new('http://localhost:3000', :username => 'ooga', :password => 'booga')
         Uri.new('http://ooga:booga@localhost:3000').should == Uri.new('http://ooga:booga@localhost:3000')
@@ -135,14 +135,14 @@ module Wrest
         Uri.new('https://localhost:3000').hash.should == Uri.new('https://localhost:3000').hash
         Uri.new('http://ooga:booga@localhost:3000').hash.should == Uri.new('http://ooga:booga@localhost:3000').hash
         Uri.new('http://localhost:3000', :username => 'ooga', :password => 'booga').hash.should == Uri.new('http://localhost:3000', :username => 'ooga', :password => 'booga').hash
-        
+
         Uri.new('https://localhost:3001').hash.should_not == Uri.new('https://localhost:3000').hash
         Uri.new('https://ooga:booga@localhost:3000').hash.should_not == Uri.new('https://localhost:3000').hash
         Uri.new('https://localhost:3000', :username => 'ooga', :password => 'booga').hash.should_not == Uri.new('https://localhost:3000').hash
         Uri.new('https://localhost:3000', :username => 'ooga', :password => 'booga').hash.should_not == Uri.new('http://localhost:3000', :username => 'foo', :password => 'bar').hash
       end
     end
-    
+
     describe 'Cloning' do
       let(:original) { Uri.new('http://localhost:3000/ooga', :default_headers => { H::ContentType => T::FormEncoded }) }
       let(:clone) { original.clone }
@@ -150,11 +150,11 @@ module Wrest
       it "should be equal to its clone" do
         original.should eq(clone)
       end
-      
+
       it "should not be the same object as the clone" do
         original.should_not be_equal(clone)
       end
-      
+
       it "should allow options to be changed when building the clone" do
         clone = original.clone(:username => 'kaiwren', :password => 'bottle')
         original.should_not == clone
@@ -162,7 +162,7 @@ module Wrest
         clone.password.should == 'bottle'
         original.username.should be_nil
       end
-      
+
       context "default headers" do
         it "merges the default headers" do
           original.clone(:default_headers => { H::Connection => T::KeepAlive }).default_headers.should eq(
@@ -170,7 +170,7 @@ module Wrest
             H::ContentType => T::FormEncoded
           )
         end
-        
+
         it "ensures incoming defaults have priority" do
           original.clone(:default_headers => { H::ContentType => T::ApplicationXml }).default_headers.should eq(
             H::ContentType => T::ApplicationXml
@@ -178,16 +178,16 @@ module Wrest
         end
       end
     end
-    
+
     describe 'HTTP actions' do
       def setup_http
-        http = mock(Net::HTTP) 
+        http = mock(Net::HTTP)
         Net::HTTP.should_receive(:new).with('localhost', 3000).and_return(http)
         http.should_receive(:read_timeout=).with(60)
         http.should_receive(:set_debug_output).with(nil)
         http
       end
-      
+
       context "GET" do
         it "should know how to get" do
           uri = "http://localhost:3000/glassware".to_uri
@@ -196,7 +196,7 @@ module Wrest
 
           request = Net::HTTP::Get.new('/glassware', {})
           Net::HTTP::Get.should_receive(:new).with('/glassware', {}).and_return(request)
-        
+
           http.should_receive(:request).with(request, nil).and_return(build_ok_response)
 
           uri.get
@@ -206,10 +206,10 @@ module Wrest
             uri = "http://localhost:3000/glassware".to_uri
 
             http = setup_http
-                
+
             request = Net::HTTP::Get.new('/glassware?owner=Kai&type=bottle', {'page' => '2', 'per_page' => '5'})
             Net::HTTP::Get.should_receive(:new).with('/glassware?owner=Kai&type=bottle', {'page' => '2', 'per_page' => '5'}).and_return(request)
-        
+
             http.should_receive(:request).with(request, nil).and_return(build_ok_response)
 
             uri.get(build_ordered_hash([[:owner, 'Kai'],[:type, 'bottle']]), :page => '2', :per_page => '5')
@@ -219,38 +219,38 @@ module Wrest
            uri = "http://localhost:3000/glassware?owner=Kai&type=bottle".to_uri
 
            http = setup_http
-                
+
            request = Net::HTTP::Get.new('/glassware?owner=Kai&type=bottle', {'page' => '2', 'per_page' => '5'})
            Net::HTTP::Get.should_receive(:new).with('/glassware?owner=Kai&type=bottle', {'page' => '2', 'per_page' => '5'}).and_return(request)
-        
+
            http.should_receive(:request).with(request, nil).and_return(build_ok_response)
 
            uri.get({}, :page => '2', :per_page => '5')
          end
-          
+
          it "should propagate http auth options while being converted to Template and back" do
            base = "http://localhost:3000/".to_uri(:username => 'ooga', :password => 'bar')
            template = base.to_template('/search/:search')
            uri = template.to_uri(:search => 'kaiwren')
      request = Wrest::Native::Get.new(uri, {}, {} ,{:username => "ooga", :password =>"bar"})
            Http::Get.should_receive(:new).with(uri,{},{},{:username => "ooga", :password =>"bar"}).and_return(request)
- 
+
     http_request = mock(Net::HTTP::Get, :method => "GET", :hash => {})
     http_request.should_receive(:basic_auth).with('ooga', 'bar')
     request.should_receive(:http_request).any_number_of_times.and_return(http_request)
     request.should_receive(:do_request).and_return(mock(Net::HTTPOK, :code => "200", :message => 'OK', :body => '', :to_hash => {}))
              uri.get
           end
-   
-           
+
+
          it "should know how to get with a ? appended to the uri and no appended parameters" do
            uri = "http://localhost:3000/glassware?".to_uri
 
            http = setup_http
-                
+
            request = Net::HTTP::Get.new('/glassware', {'page' => '2', 'per_page' => '5'})
            Net::HTTP::Get.should_receive(:new).with('/glassware', {'page' => '2', 'per_page' => '5'}).and_return(request)
-        
+
            http.should_receive(:request).with(request, nil).and_return(build_ok_response)
 
            uri.get({}, :page => '2', :per_page => '5')
@@ -260,7 +260,7 @@ module Wrest
             uri = "http://localhost:3000/glassware?".to_uri
 
             http = setup_http
-                
+
             request = Net::HTTP::Get.new('/glassware?owner=kai&type=bottle', {'page' => '2', 'per_page' => '5'})
 
             Net::HTTP::Get.should_receive(:new).with('/glassware?owner=Kai&type=bottle', {'page' => '2', 'per_page' => '5'}).and_return(request)
@@ -274,11 +274,11 @@ module Wrest
             uri = "http://localhost:3000/glassware?owner=kai&type=bottle".to_uri
 
             http = setup_http
-                
+
             request = Net::HTTP::Get.new('/glassware?owner=kai&type=bottle&param1=one&param2=two', {'page' => '2', 'per_page' => '5'})
 
             Net::HTTP::Get.should_receive(:new).with('/glassware?owner=kai&type=bottle&param1=one&param2=two', {'page' => '2', 'per_page' => '5'}).and_return(request)
-        
+
             http.should_receive(:request).with(request, nil).and_return(build_ok_response)
 
             uri.get(build_ordered_hash([[:param1, 'one'],[:param2, 'two']]), :page => '2', :per_page => '5')
@@ -288,37 +288,37 @@ module Wrest
             uri = "http://localhost:3000/glassware".to_uri
 
             http = setup_http
-        
+
             request = Net::HTTP::Get.new('/glassware?owner=Kai&type=bottle', {})
             Net::HTTP::Get.should_receive(:new).with('/glassware?owner=Kai&type=bottle', {}).and_return(request)
-        
+
             http.should_receive(:request).with(request, nil).and_return(build_ok_response)
 
             uri.get(build_ordered_hash([[:owner, 'Kai'],[:type, 'bottle']]))
           end
         end
       end
-      
+
       it "should know how to post" do
         uri = "http://localhost:3000/glassware".to_uri
 
         http = setup_http
-      
+
         request = Net::HTTP::Post.new('/glassware', {'page' => '2', 'per_page' => '5'})
         Net::HTTP::Post.should_receive(:new).with('/glassware', {'page' => '2', 'per_page' => '5'}).and_return(request)
-      
+
         http.should_receive(:request).with(request, '<ooga>Booga</ooga>').and_return(build_ok_response)
 
         uri.post '<ooga>Booga</ooga>', :page => '2', :per_page => '5'
       end
-     
+
       it "should know how to post form-encoded parameters using Uri#post_form" do
         uri = "http://localhost:3000/glassware".to_uri
 
         http = setup_http
 
         request = Net::HTTP::Post.new('/glassware', {'page' => '2', 'per_page' => '5'})
-        Net::HTTP::Post.should_receive(:new).with('/glassware', 
+        Net::HTTP::Post.should_receive(:new).with('/glassware',
                                                   'page' => '2', 'per_page' => '5', H::ContentType=>T::FormEncoded
                                                   ).and_return(request)
 
@@ -330,7 +330,7 @@ module Wrest
         uri = "http://localhost:3000/glassware".to_uri
 
         http = setup_http
-              
+
         request = Net::HTTP::Put.new('/glassware', {'page' => '2', 'per_page' => '5'})
         Net::HTTP::Put.should_receive(:new).with('/glassware', {'page' => '2', 'per_page' => '5'}).and_return(request)
 
@@ -340,7 +340,7 @@ module Wrest
       end
 
       context "DELETE" do
-        
+
         it "should know how to delete" do
           uri = "http://localhost:3000/glassware".to_uri
 
@@ -353,7 +353,7 @@ module Wrest
 
           uri.delete(build_ordered_hash([[:owner, 'Kai'],[:type, 'bottle']]), :page => '2', :per_page => '5')
         end
-      
+
         context "query parameters" do
            it "should know how to delete with parameters included in the uri" do
              uri = "http://localhost:3000/glassware?owner=Kai&type=bottle".to_uri
@@ -413,7 +413,7 @@ module Wrest
           end
         end
       end
-      
+
       it "should know how to ask for options on a URI" do
         uri = "http://localhost:3000/glassware".to_uri
 
@@ -421,7 +421,7 @@ module Wrest
 
         request = Net::HTTP::Options.new('/glassware')
         Net::HTTP::Options.should_receive(:new).with('/glassware', {}).and_return(request)
-      
+
         http.should_receive(:request).with(request, nil).and_return(build_ok_response(nil))
 
         uri.options
@@ -434,13 +434,13 @@ module Wrest
         Net::HTTP.should_receive(:new).with('localhost', 3000).any_number_of_times.and_return(http)
         http.should_receive(:read_timeout=).any_number_of_times.with(60)
         http.should_receive(:set_debug_output).any_number_of_times
-      
+
         request_get = Net::HTTP::Get.new('/glassware?owner=Kai&type=bottle', {'page' => '2', 'per_page' => '5'})
         Net::HTTP::Get.should_receive(:new).with('/glassware?owner=Kai&type=bottle', {'page' => '2', 'per_page' => '5'}).and_return(request_get)
-      
+
         request_post = Net::HTTP::Post.new('/glassware', {'page' => '2', 'per_page' => '5'})
         Net::HTTP::Post.should_receive(:new).with('/glassware', {'page' => '2', 'per_page' => '5'}).and_return(request_post)
-      
+
         http.should_receive(:request).with(request_get, nil).and_return(build_ok_response)
         http.should_receive(:request).with(request_post, '<ooga>Booga</ooga>').and_return(build_ok_response)
 
@@ -465,7 +465,7 @@ module Wrest
             uri = "http://localhost:3000/".to_uri
             uri.stub!(:create_connection).and_return(connection)
             callback_called = false
-            uri.send(http_method.to_sym) do |callback| 
+            uri.send(http_method.to_sym) do |callback|
               callback.should be_an_instance_of(Callback)
               callback_called = true
             end
@@ -477,7 +477,7 @@ module Wrest
             on_ok = false
             uri = "http://localhost:3000/".to_uri
             uri.stub!(:create_connection).and_return(connection)
-            uri.send(http_method.to_sym) do |callback| 
+            uri.send(http_method.to_sym) do |callback|
               callback.on_ok{|response| on_ok = true}
             end
             on_ok.should be_true
@@ -492,6 +492,16 @@ module Wrest
             on_ok.should be_true
           end
 
+          it "should execute the uri callback after receiving a successful response on sub path" do
+            connection = setup_connection
+            on_ok = false
+            base_uri = "http://localhost:3000/".to_uri(:callback => {200 => lambda{|response| on_ok = true}})
+            uri = base_uri['glassware']
+            uri.stub(:create_connection).and_return(connection)
+            uri.send(http_method.to_sym)
+            on_ok.should be_true
+          end
+
           it "should execute both callbacks after the successful response is received" do
             connection = setup_connection
             on_ok = false
@@ -501,7 +511,7 @@ module Wrest
             block = lambda do |callback|
               callback.on_ok{|response| another_ok = true }
             end
-            uri.send(http_method.to_sym) do |callback| 
+            uri.send(http_method.to_sym) do |callback|
               callback.on_ok{|response| another_ok = true }
             end
             on_ok.should be_true
@@ -518,7 +528,7 @@ module Wrest
               uri = "http://localhost:3000/".to_uri
               uri.stub!(:create_connection).and_return(connection)
               callback_called = false
-              uri.send(http_method.to_sym) do |callback| 
+              uri.send(http_method.to_sym) do |callback|
                 callback.is_a?(Callback).should be_true
                 callback_called = true
               end
@@ -530,7 +540,7 @@ module Wrest
               on_ok = false
               uri = "http://localhost:3000/".to_uri
               uri.stub!(:create_connection).and_return(connection)
-              uri.send(http_method.to_sym) do |callback| 
+              uri.send(http_method.to_sym) do |callback|
                 callback.on_ok{|response| on_ok = true}
               end
               on_ok.should be_true
@@ -541,7 +551,17 @@ module Wrest
               on_ok = false
               uri = "http://localhost:3000/".to_uri(:callback => {200 => lambda{|response| on_ok = true}})
               uri.stub(:create_connection).and_return(connection)
-              uri.send(http_method.to_sym) 
+              uri.send(http_method.to_sym)
+              on_ok.should be_true
+            end
+
+            it "should execute the uri callback after receiving a successful response on subpath" do
+              connection = setup_connection
+              on_ok = false
+              base_uri = "http://localhost:3000/".to_uri(:callback => {200 => lambda{|response| on_ok = true}})
+              uri = base_uri['glassware']
+              uri.stub(:create_connection).and_return(connection)
+              uri.send(http_method.to_sym)
               on_ok.should be_true
             end
 
@@ -554,9 +574,9 @@ module Wrest
               block = lambda do |callback|
                 callback.on_ok {|response| another_ok = true}
               end
-              uri.send(http_method.to_sym) do |callback| 
+              uri.send(http_method.to_sym) do |callback|
                 callback.on_ok {|response| another_ok = true}
-              end 
+              end
               on_ok.should be_true
               another_ok.should be_true
             end
@@ -570,7 +590,7 @@ module Wrest
           uri = "http://localhost:3000/".to_uri
           uri.stub!(:create_connection).and_return(connection)
           callback_called = false
-          uri.post_form do |callback| 
+          uri.post_form do |callback|
             callback.is_a?(Callback).should be_true
             callback_called = true
           end
@@ -583,7 +603,7 @@ module Wrest
           uri = "http://localhost:3000/".to_uri
           uri.stub!(:create_connection).and_return(connection)
           request = Wrest::Native::Post.new(uri)
-          uri.post_form do |callback| 
+          uri.post_form do |callback|
             callback.on_ok{|response| on_ok = true}
           end
           on_ok.should be_true
@@ -594,7 +614,17 @@ module Wrest
           on_ok = false
           uri = "http://localhost:3000/".to_uri(:callback => {200 => lambda{|response| on_ok = true}})
           uri.stub(:create_connection).and_return(connection)
-          uri.post_form 
+          uri.post_form
+          on_ok.should be_true
+        end
+
+        it "should execute the uri callback after receiving a successful response on sub path" do
+          connection = setup_connection
+          on_ok = false
+          base_uri = "http://localhost:3000/".to_uri(:callback => {200 => lambda{|response| on_ok = true}})
+          uri = base_uri['glassware']
+          uri.stub(:create_connection).and_return(connection)
+          uri.post_form
           on_ok.should be_true
         end
 
@@ -607,7 +637,7 @@ module Wrest
           block = lambda do |callback|
             callback.on_ok{|response| another_ok = true}
           end
-          uri.post_form do |callback| 
+          uri.post_form do |callback|
             callback.on_ok{|response| another_ok = true}
           end
           on_ok.should be_true
@@ -624,7 +654,7 @@ module Wrest
         it "lets incoming default_headers take precedence when the Uri is extended" do
           uri['/foo', {:default_headers => content_type_header}].default_headers.should eq(content_type_header)
         end
-        
+
         {
           'get' => {},
           'delete' => {},
@@ -635,36 +665,36 @@ module Wrest
             it "sets the default headers if there are no request headers" do
               uri.send("build_#{verb}").headers.should eq(oauth_header)
             end
-          
+
             it "merges the default headers into the request headers" do
-              uri.send("build_#{verb}", blank_first_param_value, 
+              uri.send("build_#{verb}", blank_first_param_value,
                         content_type_header
                       ).headers.should eq(oauth_header.merge(content_type_header))
             end
-          
+
             it "lets the incoming headers take precedent over the defaults" do
               uri.send("build_#{verb}", blank_first_param_value, alternative_oauth_header).headers.should eq(alternative_oauth_header)
             end
           end
         end
-        
+
         context "POST (form-encoded)" do
           it "sets the default headers if there are no request headers" do
             uri.build_post_form.headers.should eq(oauth_header.merge(Wrest::H::ContentType => Wrest::T::FormEncoded))
           end
-        
+
           it "merges the default headers into the request headers" do
             uri.build_post_form({}, content_type_header).headers.should eq(
                                           oauth_header.merge(content_type_header).merge(Wrest::H::ContentType => Wrest::T::FormEncoded)
                                         )
           end
-        
+
           it "lets the incoming headers take precedent over the defaults" do
             uri.build_post_form({}, alternative_oauth_header).headers.should eq(alternative_oauth_header.merge(Wrest::H::ContentType => Wrest::T::FormEncoded))
           end
         end
       end
-      
+
       context "asynchronous", :functional => true do
         let(:hash){Hash.new}
 
@@ -761,6 +791,6 @@ module Wrest
           end
         end
       end
-    end  
+    end
   end
 end


### PR DESCRIPTION
Fixes the issue where callbacks are not being cloned into sub path uris

```
[1] pry(main)> b = 'http://google.com'.to_uri(
[1] pry(main)*   :callback => {
[1] pry(main)*     200..499 => lambda { |r| p r.message }
[1] pry(main)*   }
[1] pry(main)* )
=> http://google.com
[2] pry(main)> b['contacts'].get
TypeError: can't clone NilClass
from /home/phoenix/.rbenv/versions/1.9.3-p194/lib/ruby/gems/1.9.1/gems/wrest-1.5.0/lib/wrest/callback.rb:24:in `clone'
```
