### PR TITLE
Allow support for ActiveSupport~>5

### DIFF
--- a/lib/wrest/components/container/typecaster.rb
+++ b/lib/wrest/components/container/typecaster.rb
@@ -24,7 +24,8 @@ module Wrest
       def self.included(klass) #:nodoc:
         klass.extend Typecaster::ClassMethods
         klass.class_eval{ include Typecaster::InstanceMethods }
-        klass.alias_method_chain  :initialize,  :typecasting
+        klass.send(:alias_method, :initialize_without_typecasting, :initialize)
+        klass.send(:alias_method, :initialize, :initialize_with_typecasting)
       end
 
       module Helpers

--- a/lib/wrest/native/get.rb
+++ b/lib/wrest/native/get.rb
@@ -55,7 +55,8 @@ module Wrest::Native
       cache_proxy.get
     end
 
-    alias_method_chain :invoke, :cache_check
+    alias_method :invoke_without_cache_check, :invoke
+    alias_method :invoke, :invoke_with_cache_check
 
     def build_request_without_cache_store(cache_validation_headers)
       new_headers = headers.clone.merge cache_validation_headers

--- a/lib/wrest/native/request.rb
+++ b/lib/wrest/native/request.rb
@@ -80,6 +80,8 @@ module Wrest::Native
     # The request hash is followed by a connection hash; requests using the
     # same connection (effectively a keep-alive connection) will have the
     # same connection hash.
+    # 
+    # Passing nil for either username or password will skip HTTP authentication
     #
     # This is followed by the response code, the payload size and the time taken.
     def invoke

--- a/lib/wrest/uri.rb
+++ b/lib/wrest/uri.rb
@@ -36,6 +36,7 @@ module Wrest #:nodoc:
     #                            defaults if there are any clashes. Use this to set cookies or use OAuth2 Authorize
     #                            headers. When extending or cloning a Uri, passing in a new set of default_headers
     #                            will result in the old set being overridden.
+    #   :username, :password  => HTTP authentication. Passing nil for either username or password will skip it.
     # See Wrest::Native::Request for other available options and their default values.
     def initialize(uri_string, options = {})
       @options = options.clone

--- a/wrest.gemspec
+++ b/wrest.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "rspec", ["~> 3.3"]
   s.add_development_dependency "sinatra", ["~> 1.0.0"]
 
-  s.add_runtime_dependency "activesupport", ["~> 4"]
+  s.add_runtime_dependency "activesupport", ["~> 5"]
   s.add_runtime_dependency "builder", ["> 2.0"]
   s.add_runtime_dependency "multi_json", ["~> 1.0"]
   s.add_runtime_dependency "concurrent-ruby", ["~> 1.0"]


### PR DESCRIPTION
The gem was not compatible with activesupport~>5 because of the use of deprecated keyword alias_method_chain, which when replaced with alias_method works fine.